### PR TITLE
Use exec form for Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY --chown=app src /app
 WORKDIR /app
 USER app
 
-CMD /app/serve.py
+CMD ["/app/serve.py"]


### PR DESCRIPTION
The shell form prevents signals from propagating to the app.